### PR TITLE
Ajout de dependent: :destroy

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ApplicationRecord
-  has_many :items
-  has_many :subcategories, class_name: 'Category', foreign_key: 'parent_id'
+  has_many :items, dependent: :destroy
+  has_many :subcategories, class_name: 'Category', foreign_key: 'parent_id', dependent: :destroy
   belongs_to :parent_category, class_name: 'Category', optional: true
 
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :items
+  has_many :items, dependent: :destroy
 end


### PR DESCRIPTION
Ajout des  dependent: :destroy pour que  : 

- quand on supprime un utilisateur, tous les éléments associés sont aussi  supprimés.
- quand on supprime une catégorie,  tous les éléments et sous-catégories associés sont aussi supprimés.

Bonne relecture 🌻


